### PR TITLE
doc: update install procedure regarding GO updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Installation
 ------------
 To install cli, simply run:
 ```
-$ go get github.com/ovh/ldp-tail
+$ go install github.com/ovh/ldp-tail@latest
 ```
 
 Usage


### PR DESCRIPTION
Hi, I just installed ldp-tail, 
and with GO 1.18.2 the install command is ``go install github.com/ovh/ldp-tail@latest``

Here is the README.md update